### PR TITLE
Remove rt::unwind

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,6 @@ pub unsafe extern "C" fn __afl_rs_init() {
             intrinsics::abort();
         }
     }
-
-    if env::var_os("AFL_RS_CRASH_ON_PANIC").is_some() {
-        if !rt::unwind::register(crash) {
-            exit(1);
-        }
-    }
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
`rt::unwind` has been removed from Rust. For this reason this crate stopped compiling on current nightly.

To crash on panic the compiler option `-Z no-landing-pads` can be set.