### PR TITLE
plugin: fix build

### DIFF
--- a/plugin/src/afl-llvm-pass.so.cc
+++ b/plugin/src/afl-llvm-pass.so.cc
@@ -74,8 +74,8 @@ bool AFLCoverage::runOnModule(Module &M) {
 
   /* Decide instrumentation ratio */
 
-  char* inst_ratio_str = getenv("AFL_INST_RATIO");
-  int   inst_ratio     = 100;
+  char*    inst_ratio_str = getenv("AFL_INST_RATIO");
+  unsigned inst_ratio     = 100;
 
   if (inst_ratio_str) {
 


### PR DESCRIPTION
src/afl-llvm-pass.so.cc:82:49: error: format '%u' expects argument of type 'unsigned int*', but argument 3 has type 'int*' [-Werror=format=]

Signed-off-by: Marc-Antoine Perennou <Marc-Antoine@Perennou.com>