### PR TITLE
Check for existence of 'fuzzer_stats' file for integration test, fix afl-sys on Linux.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ mod test {
         let temp_dir_path = temp_dir.path();
         let mut child = Command::new("target/debug/cargo-afl-fuzz")
             .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
             .arg("-i")
             .arg(".")
             .arg("-o")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ pub unsafe fn init() {
 #[cfg(test)]
 mod test {
     use std::process::{Command, Stdio};
-    use std::fs;
     use std::thread;
     use std::time;
 
@@ -51,7 +50,6 @@ mod test {
             .expect("Could not run cargo-afl-fuzz");
         thread::sleep(time::Duration::from_secs(7));
         child.kill().unwrap();
-        let mut entries = fs::read_dir(temp_dir_path.join("queue")).expect("Could not read AFL out directory");
-        assert!(entries.next().is_some());
+        assert!(temp_dir_path.join("fuzzer_stats").is_file());
     }
 }


### PR DESCRIPTION
The 'queue' directory gets created, regardless of whether AFL actually
ran or not, unlike the 'fuzzer_stats' file.