### PR TITLE
Add rust-lang.org markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ arising from `unsafe` code. Pull requests are welcome!
 [fuzz testing]: https://en.wikipedia.org/wiki/Fuzz_testing
 [rustup]: https://rustup.rs/
 [american-fuzzy-lop]: http://lcamtuf.coredump.cx/afl/
+[rust]: https://www.rust-lang.org


### PR DESCRIPTION
I think this was the intention and fixes this from the "What is it" paragraph:
`[the Rust programming language][rust].`
Making markdown interpret it as a link instead.